### PR TITLE
Update conda and use new faster solver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,11 +43,14 @@ RUN apt-get update && \
 # Miniconda
 ARG conda_dir="/usr/miniconda3"
 ENV PATH="${conda_dir}/bin:${PATH}"
-ARG mconda="Miniconda3-py38_4.12.0-Linux-x86_64.sh"
+ARG mconda="Miniconda3-py38_23.1.0-1-Linux-x86_64.sh"
 RUN wget \
     https://repo.anaconda.com/miniconda/"$mconda" && \
     bash "$mconda" -p "$conda_dir" -b && \
-    rm -f "$mconda"
+    rm -f "$mconda" && \
+    conda install -n base conda-libmamba-solver && \
+    conda config --set solver libmamba
+
 # Create conda env
 ARG cenv="customer-env.yml"
 COPY "$cenv" .


### PR DESCRIPTION
On EC2 instance now it takes 14 min to build vs 22.

https://www.anaconda.com/blog/conda-is-fast-now